### PR TITLE
Fix: JSONBMap type assertion for string type

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -212,6 +212,7 @@ func autoMigrate() error {
 		&model.Organization{},
 		&model.Order{},
 		&model.WorkOrder{},
+		&model.Tenant{},
 	}
 
 	for _, m := range models {

--- a/internal/model/tenant.go
+++ b/internal/model/tenant.go
@@ -11,7 +11,7 @@ import (
 
 // Tenant represents a multi-tenant organization in the system
 type Tenant struct {
-	ID            uint         `gorm:"primaryKey;autoIncrement"`
+	ID            uint           `gorm:"primaryKey;autoIncrement"`
 	Name          string         `gorm:"size:255;not null;comment:租户全称"`
 	Code          string         `gorm:"size:100;uniqueIndex;not null;comment:唯一标识码"`
 	ContactPerson string         `gorm:"size:255;comment:联系人"`
@@ -44,16 +44,21 @@ func (j *JSONBMap) Scan(src interface{}) error {
 		*j = make(JSONBMap)
 		return nil
 	}
-	
-	data, ok := src.([]byte)
-	if !ok {
-		return fmt.Errorf("type assertion to []byte failed")
+
+	var data []byte
+	switch v := src.(type) {
+	case []byte:
+		data = v
+	case string:
+		data = []byte(v)
+	default:
+		return fmt.Errorf("cannot scan %T into JSONBMap", src)
 	}
-	
+
 	if len(data) == 0 || string(data) == "{}" {
 		*j = make(JSONBMap)
 		return nil
 	}
-	
+
 	return json.Unmarshal(data, j)
 }

--- a/internal/model/tenant_repro_test.go
+++ b/internal/model/tenant_repro_test.go
@@ -1,0 +1,61 @@
+package model
+
+import (
+	"testing"
+)
+
+func TestJSONBMap_Scan(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     interface{}
+		wantErr bool
+	}{
+		{
+			name:    "nil input",
+			src:     nil,
+			wantErr: false,
+		},
+		{
+			name:    "empty bytes",
+			src:     []byte("{}"),
+			wantErr: false,
+		},
+		{
+			name:    "valid JSON bytes",
+			src:     []byte(`{"key": "value"}`),
+			wantErr: false,
+		},
+		{
+			name:    "string type - was BUG now fixed",
+			src:     `{"key": "value"}`,
+			wantErr: false, // Fixed: now handles string type
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			j := make(JSONBMap)
+			err := j.Scan(tt.src)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("JSONBMap.Scan() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestJSONBMapScan_StringBug specifically tests the bug case
+func TestJSONBMapScan_StringBug(t *testing.T) {
+	j := make(JSONBMap)
+
+	// This is what PostgreSQL driver returns in some cases
+	err := j.Scan(`{"test": "data"}`)
+	if err != nil {
+		t.Errorf("BUG NOT FIXED: %v", err)
+	}
+
+	// Verify the data was parsed correctly
+	if v, ok := j["test"]; !ok || v != "data" {
+		t.Errorf("Expected test=data, got %v", v)
+	}
+	t.Log("BUG FIXED: string type now handled correctly")
+}


### PR DESCRIPTION
## Problem
Tenant creation fails with error: `type assertion to []byte failed`

PostgreSQL driver may return `string` for jsonb fields instead of `[]byte`,
causing the Scan() method to fail.

## Solution
- Fix `JSONBMap.Scan()` to handle both `[]byte` and `string` types
- Add comprehensive test coverage
- Include Tenant model in AutoMigrate

## Changes
- `internal/model/tenant.go`: Fix Scan() type assertion
- `internal/model/tenant_repro_test.go`: Add tests
- `cmd/api/main.go`: Add Tenant to AutoMigrate

## Testing
- All tests pass
- Build succeeds

Fixes #7